### PR TITLE
Allow the user to specify output location and name of image_transport

### DIFF
--- a/h264_video_encoder/launch/h264_video_encoder.launch
+++ b/h264_video_encoder/launch/h264_video_encoder.launch
@@ -11,11 +11,11 @@
     <!-- If a node_name argument is provided by the caller then we will set the node's name to that value -->
     <arg name="node_name" default="h264_video_encoder" />
     <!-- If a config file argument is provided by the caller then we will load it into the node's namespace -->
-    <arg name="config_file" default="" />
+    <arg name="config_file" default="" doc="Path to config file. All configuration settings will be loaded into node's namespace." />
     <!-- The output argument sets the node's stdout/stderr location. Set to 'screen' to see this node's output in the terminal. -->
-    <arg name="output" default="log" />
-    <!-- The image transport used by the video encoder. This can be 'raw' or 'compressed -->
-    <arg name="image_transport" default="compressed" />
+    <arg name="output" default="log" doc="The stdout/stderr location for this node. Set to 'screen' to see this node's output in the terminal." />
+    <!-- The image transport used by the video encoder. This can be 'raw' or 'compressed' -->
+    <arg name="image_transport" default="compressed" doc="The image transport used by this video encoder node. This can be 'raw' or 'compressed'." />
 
     <node name="$(arg node_name)" pkg="h264_video_encoder" type="h264_video_encoder" output="$(arg output)">
         <!-- If the caller specified a config file then load it here. -->

--- a/h264_video_encoder/launch/h264_video_encoder.launch
+++ b/h264_video_encoder/launch/h264_video_encoder.launch
@@ -12,12 +12,16 @@
     <arg name="node_name" default="h264_video_encoder" />
     <!-- If a config file argument is provided by the caller then we will load it into the node's namespace -->
     <arg name="config_file" default="" />
+    <!-- The output argument sets the node's stdout/stderr location. Set to 'screen' to see this node's output in the terminal. -->
+    <arg name="output" default="log" />
+    <!-- The image transport used by the video encoder. This can be 'raw' or 'compressed -->
+    <arg name="image_transport" default="compressed" />
 
-    <node name="$(arg node_name)" pkg="h264_video_encoder" type="h264_video_encoder">
+    <node name="$(arg node_name)" pkg="h264_video_encoder" type="h264_video_encoder" output="$(arg output)">
         <!-- If the caller specified a config file then load it here. -->
         <rosparam if="$(eval config_file!='')" command="load" file="$(arg config_file)"/>
 
         <!-- Name of image transport to use when subscribing to a sensor message topic -->
-        <param name="image_transport" value="compressed"/>
+        <param name="image_transport" value="$(arg image_transport)"/>
     </node>
 </launch>


### PR DESCRIPTION
This allows the user to send output to their screen instead of the default of 'log' when including the h264_video_encoder.launch file inside their own launch file. log is the default output value when it's not set (see http://wiki.ros.org/roslaunch/XML/node).

This also allows the user to change the name of the image_transport used with the node. It defaults to "compressed" as it did previously. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
