### PR TITLE
Restrict aws robotics dependencies

### DIFF
--- a/h264_video_encoder/package.xml
+++ b/h264_video_encoder/package.xml
@@ -14,18 +14,18 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>h264_encoder_core</build_depend>
-  <build_depend>aws_ros1_common</build_depend>
+  <build_depend version_lt='2.0.0'>aws_ros1_common</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>kinesis_video_msgs</build_depend>
+  <build_depend version_lt='2.0.0'>kinesis_video_msgs</build_depend>
 
   <exec_depend>image_transport</exec_depend>
   <exec_depend>image_transport_plugins</exec_depend>
-  <exec_depend>aws_ros1_common</exec_depend>
+  <exec_depend version_lt='2.0.0'>aws_ros1_common</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>kinesis_video_msgs</exec_depend>
+  <exec_depend version_lt='2.0.0'>kinesis_video_msgs</exec_depend>
 
   <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
*Description of changes:*
Sets the aws-robotics depends less than 2.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
