### PR TITLE
Modifying build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The source code is released under [LGPL 2.1]. However, this package uses `h264_e
 
 ### Supported ROS Distributions
 - Kinetic
-- Lunar
 - Melodic
 
 ### Build status

--- a/README.md
+++ b/README.md
@@ -27,25 +27,35 @@ The source code is released under [LGPL 2.1]. However, this package uses `h264_e
 
 ## Installation
 
+### Binaries
+On Ubuntu you can install the latest version of this package using the following command
+
+        sudo apt-get update
+        sudo apt-get install -y ros-kinetic-h264-video-encoder
+        
+        
 ### Building from Source
-Create a ROS workspace and a source directory
+
+To build from source you'll need to create a new workspace, clone and checkout the latest release branch of this repository, install all the dependencies, and compile. If you need the latest development features you can clone from the `master` branch instead of the latest release branch. While we guarantee the release branches are stable, __the `master` should be considered to have an unstable build__ due to ongoing development. 
+
+- Create a ROS workspace and a source directory
 
     mkdir -p ~/ros-workspace/src
 
-To build from source, clone the latest version from master branch and compile the package.
+- Clone the package into the source directory . 
 
-- Clone the package into the source directory
+_Note: Replace __`{MAJOR.VERSION}`__ below with the latest major version number to get the latest release branch._
 
         cd ~/ros-workspace/src
-        git clone https://github.com/aws/aws-ros-utils-common.git
-        git clone https://github.com/aws/aws-ros-utils-ros1.git
-        git clone https://github.com/aws/aws-ros-kinesisvideo-encoder-common.git
-        git clone https://github.com/aws/aws-ros-kinesisvideo-encoder-ros1.git
+        git clone https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git -b release-v{MAJOR.VERSION}
 
 - Install dependencies
 
-        cd ~/ros-workspace && sudo apt-get update
+        cd ~/ros-workspace 
+        sudo apt-get update && rosdep update
         rosdep install --from-paths src --ignore-src -r -y
+        
+_Note: If building the master branch instead of a release branch you may need to also checkout and build the master branches of the packages this package depends on._
 
 - Build the packages
 
@@ -54,6 +64,7 @@ To build from source, clone the latest version from master branch and compile th
 - Configure ROS library Path
 
         source ~/ros-workspace/install/setup.bash
+
 
 - Build and run the unit tests
 


### PR DESCRIPTION
The current build instructions tell you to git clone this repository and all the dependent repositories from the master branch. However, we want to consider the master branch unstable for development and instruct users to build from source using the release branches if they don't need the cutting edge features.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
