### PR TITLE
Adds h264_encoder_core as exec_depend

### DIFF
--- a/h264_video_encoder/package.xml
+++ b/h264_video_encoder/package.xml
@@ -12,21 +12,22 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>h264_encoder_core</build_depend>
   <build_depend>aws_ros1_common</build_depend>
+  <build_depend>h264_encoder_core</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>kinesis_video_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>kinesis_video_msgs</build_depend>
 
+  <exec_depend>aws_ros1_common</exec_depend>
+  <exec_depend>h264_encoder_core</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>image_transport_plugins</exec_depend>
-  <exec_depend>aws_ros1_common</exec_depend>
+  <exec_depend>kinesis_video_msgs</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>kinesis_video_msgs</exec_depend>
 
-  <test_depend>gtest</test_depend>
   <test_depend>google-mock</test_depend>
+  <test_depend>gtest</test_depend>
   <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
This commit adds h264_encoder_core as an execution dependency. It also puts the dependencies into alphabetic order.

*Issue #, if available:*
https://t.corp.amazon.com/P27153985

*Description of changes:*
This commit adds h264_encoder_core as an execution dependency. It also puts the dependencies into alphabetic order.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
